### PR TITLE
Bill refactor

### DIFF
--- a/poros/bill_aggregator.rb
+++ b/poros/bill_aggregator.rb
@@ -22,7 +22,7 @@ class BillAggregator
       votes.each do |vote|
         if vote[:question] == "On Passage" ||
            vote[:question] == "On Motion to Suspend the Rules and Pass"
-          bill_list << filter_bill_info(vote, "house", offset)
+          bill_list << filter_bill_info(vote, "house")
         end
       end
       offset += 20
@@ -39,7 +39,7 @@ class BillAggregator
       votes = @service.member_vote("S001191", offset)[:results].first[:votes]
       votes.each do |vote|
         if vote[:question] == "On Passage of the Bill"
-          bill_list << filter_bill_info(vote, "senate", offset)
+          bill_list << filter_bill_info(vote, "senate")
         end
       end
       offset += 20
@@ -47,10 +47,10 @@ class BillAggregator
     bill_list
   end
 
-  def filter_bill_info(vote, chamber, offset)
+  def filter_bill_info(vote, chamber)
     bill_id = vote[:bill][:bill_id].chomp("-116")
     bill_vote_info = { (chamber + "_roll_call").to_sym => vote[:roll_call].to_i,
-                       (chamber + "_offset").to_sym => offset }
+                       (chamber + "_session").to_sym => vote[:session].to_i }
     { bill_id.to_sym => bill_vote_info }
   end
 

--- a/poros/bill_aggregator.rb
+++ b/poros/bill_aggregator.rb
@@ -13,7 +13,7 @@ class BillAggregator
   end
 
   def aggregate_house_bills
-    house_votes = @service.total_house_votes
+    house_votes = @service.total_votes("O000172")
     num_votes = house_votes[:results].first[:roles].first[:total_votes]
     offset = 0
     bill_list = []
@@ -31,7 +31,7 @@ class BillAggregator
   end
 
   def aggregate_senate_bills
-    senate_votes = @service.total_senate_votes
+    senate_votes = @service.total_votes("S001191")
     num_votes = senate_votes[:results].first[:roles].first[:total_votes]
     offset = 0
     bill_list = []

--- a/represent_app.rb
+++ b/represent_app.rb
@@ -1,11 +1,12 @@
 require 'sinatra'
 require "sinatra/namespace"
 require './poros/bill_aggregator'
-require './serializers/member_vote_serializer'
 require './services/propublica_service'
 require './services/news_api_service'
+require './services/image_repo_service'
 require './serializers/article_serializer'
 require './serializers/bill_serializer'
+require './serializers/member_vote_serializer'
 require './serializers/representative_serializer'
 require './serializers/senator_serializer'
 
@@ -45,7 +46,10 @@ namespace '/api/v1' do
 
   get '/bills' do
     bill_list = BillAggregator.new.aggregate_bills
-    BillSerializer.new(bill_list).json_api
+    api_data = BillSerializer.new(bill_list).json_api
+    File.open("./bills.json", "w") do |f|
+      f.write(api_data)
+    end
   end
 
   get '/member_votes' do
@@ -55,7 +59,13 @@ namespace '/api/v1' do
     json = get_propublica.member_vote(member_id, offset)
 
     MemberVoteSerializer.new(json).json_api
-  end 
+  end
+
+  get '/images' do
+    congress_id = params[:congress_id]
+
+    get_image_repo.get_image(congress_id)
+  end
 
 end
 
@@ -67,4 +77,8 @@ end
 
 def get_news_api
   NewsapiService.new
+end
+
+def get_image_repo
+  ImageRepoService.new
 end

--- a/represent_app.rb
+++ b/represent_app.rb
@@ -46,19 +46,17 @@ namespace '/api/v1' do
 
   get '/bills' do
     bill_list = BillAggregator.new.aggregate_bills
-    api_data = BillSerializer.new(bill_list).json_api
-    File.open("./bills.json", "w") do |f|
-      f.write(api_data)
-    end
+    BillSerializer.new(bill_list).json_api
   end
 
   get '/member_votes' do
     member_id = params[:member_id]
-    offset = params[:offset]
+    chamber = params[:chamber]
+    session = params[:session]
+    roll_call = params[:roll_call]
 
-    json = get_propublica.member_vote(member_id, offset)
-
-    MemberVoteSerializer.new(json).json_api
+    json = get_propublica.roll_call_vote(chamber, session, roll_call)
+    MemberVoteSerializer.new(member_id, json).json_api
   end
 
   get '/images' do

--- a/serializers/bill_serializer.rb
+++ b/serializers/bill_serializer.rb
@@ -50,9 +50,9 @@ class BillSerializer
     bill_info.delete_if {|key, value| !needed_attr.include?(key)}
     bill_info[:congress_url] = bill_info.delete(:congressdotgov_url)
     bill_info[:senate_roll_call] = bill_hash[:senate_roll_call]
-    bill_info[:senate_offset] = bill_hash[:senate_offset]
+    bill_info[:senate_session] = bill_hash[:senate_session]
     bill_info[:house_roll_call] = bill_hash[:house_roll_call]
-    bill_info[:house_offset] = bill_hash[:house_offset]
+    bill_info[:house_session] = bill_hash[:house_session]
     bill_info
   end
 

--- a/serializers/bill_serializer.rb
+++ b/serializers/bill_serializer.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class BillSerializer
 
   def initialize(bill_list)
@@ -5,7 +7,7 @@ class BillSerializer
   end
 
   def json_api
-    {data: compile_bill_list}.to_json
+    JSON.pretty_generate({data: compile_bill_list})
   end
 
   private

--- a/serializers/bill_serializer.rb
+++ b/serializers/bill_serializer.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 class BillSerializer
 
   def initialize(bill_list)
@@ -7,7 +5,7 @@ class BillSerializer
   end
 
   def json_api
-    JSON.pretty_generate({data: compile_bill_list})
+    {data: compile_bill_list}.to_json
   end
 
   private

--- a/serializers/member_vote_serializer.rb
+++ b/serializers/member_vote_serializer.rb
@@ -2,20 +2,24 @@ require '././services/propublica_service'
 
 class MemberVoteSerializer
 
-  def initialize(json)
-    @bill_votes = json[:results].first[:votes]
+  def initialize(member_id, json)
+    @member_id = member_id
+    @vote = json[:results][:votes][:vote]
   end
 
   def json_api
-    {data: clean_member_vote(@bill_votes)}.to_json
+    {data: find_member_vote}.to_json
   end
 
-  def clean_member_vote(bill_votes)
-    votes_hash = {}
-    bill_votes.each do |vote|
-      votes_hash[vote[:roll_call]] = vote[:position]
-    end 
+  private
 
-    votes_hash
-  end 
+  def find_member_vote
+    member_vote = { @vote[:roll_call] => nil }
+    @vote[:positions].each do |congress|
+      if congress[:member_id] = @member_id
+        member_vote[@vote[:roll_call]] = congress[:vote_position]
+      end
+    end
+    member_vote
+  end
 end

--- a/services/propublica_service.rb
+++ b/services/propublica_service.rb
@@ -14,16 +14,16 @@ class PropublicaService
     get_json("/congress/v1/116/bills/#{bill_id}.json")
   end
 
-  def total_senate_votes
-    get_json("/congress/v1/members/S001191.json")
-  end
-
-  def total_house_votes
-    get_json("/congress/v1/members/O000172.json")
+  def total_votes(member_id)
+    get_json("/congress/v1/members/#{member_id}.json")
   end
 
   def member_vote(member_id, offset)
     get_json("/congress/v1/members/#{member_id}/votes.json", { offset: offset })
+  end
+
+  def roll_call_vote(chamber, session, roll_call)
+    get_json("/congress/v1/116/#{chamber}/sessions/#{session}/votes/#{roll_call}.json")
   end
 
   private


### PR DESCRIPTION
Refactors the Bill aggregator PORO and serializer to find the session info (which is static) instead of the offset info (which fluctuates and might break). Changed the member vote endpoint and serializer to accommodate those changes